### PR TITLE
[sandbox] INFRA-1560 rbac patch for ibm licensing operator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,33 @@ rules:
   - servicecas
   verbs:
   - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  - services
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - watch
+  - get
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubectl-apply.sh
+++ b/kubectl-apply.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+export licensing_namespace=ibm-common-services
+kubectl create namespace ${licensing_namespace} || echo "namespace probably already exists"
+
+# To add CRD:
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicenseservicereporters.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingdefinitions.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingquerysources.yaml
+
+# To add RBAC:
+kubectl apply -f config/rbac/role.yaml
+kubectl apply -f config/rbac/role_operands.yaml
+kubectl apply -f config/rbac/service_account.yaml
+kubectl apply -f config/rbac/role_binding.yaml
+
+# To configure operator
+kubectl apply -f config/manager/manager.yaml
+
+# to deploy licensing service itself
+kubectl apply -n ibm-common-services  -f licensing-service.yml

--- a/licensing-service.yml
+++ b/licensing-service.yml
@@ -1,0 +1,9 @@
+apiVersion: operator.ibm.com/v1alpha1
+kind: IBMLicensing
+metadata:
+  name: instance
+spec:
+  datasource: datacollector
+  httpsCertsSource: self-signed
+  httpsEnable: true
+  instanceNamespace: ibm-common-services


### PR DESCRIPTION
# What changed?

This PR provides the changes needed to the role.yaml file to get ibm-licensing-operator working. It also includes a sample kubectl-apply.sh script and licensing-service.yaml definition for deploying an actual instance of the license service.

The changes to role.yaml and the extra `instanceNamespace: ibm-common-services` setting in the licensing-service.yml file were undocumented changes that were necessary to get the operator and license service to work.

![image](https://github.com/moovfinancial/ibm-licensing-operator/assets/7990664/eca4a027-c740-4de8-a219-0b63b7c606c8)
